### PR TITLE
Fix deprecation warnings

### DIFF
--- a/tasks/apache2-passenger.yml
+++ b/tasks/apache2-passenger.yml
@@ -26,4 +26,4 @@
   user:
     name: "{{ redmine_webserver_user }}"
     groups: "{{ redmine_group }}"
-  when: not redmine_webserver_user in getent_group['{{ redmine_group }}'][2]
+  when: not redmine_webserver_user in getent_group[redmine_group][2]

--- a/tasks/git.yml
+++ b/tasks/git.yml
@@ -1,9 +1,8 @@
 ---
 - name: Git - Ensure prerequisites packages are installed.
   apt:
-    package: "{{ item }}"
+    package: "{{ redmine_git_packages }}"
     state: present
-  with_items: "{{ redmine_git_packages }}"
 
 - name: Git - Is this your first time?
   stat:


### PR DESCRIPTION
~~The “installed” state and calling the apt module in a loop are both
deprecated actions.~~

Edit: Using jinja2 escape sequences in `when` clauses and calling the apt module in a loop are both deprecated actions.