### PR TITLE
Unicorn

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,4 @@
+---
+- name: Reload systemd
+  systemd:
+    daemon_reload: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,6 +38,17 @@
     recurse: yes
   with_items: "{{ redmine_writable_dirs }}"
 
+- name: Ensure redmine tmp directory is populated
+  file:
+    path: "{{ item }}"
+    owner: "{{ redmine_user }}"
+    group: "{{ redmine_group }}"
+    recurse: yes
+    state: directory
+  loop:
+  - "{{ redmine_home }}/tmp/sockets"
+  - "{{ redmine_home }}/tmp/pids"
+
 - name: Ensure configuration file is present.
   template:
     src: "configuration.yml.j2"

--- a/tasks/unicorn.yml
+++ b/tasks/unicorn.yml
@@ -1,0 +1,29 @@
+---
+- name: Install unicorn as gem
+  gem:
+    name: unicorn
+    version: 5.4.1
+    executable: "{{ redmine_home }}/.rbenv/shims/gem"
+    user_install: no
+    install_dir: "{{ redmine_home }}/.rbenv/versions/{{ unicorn_ruby_version }}/lib/ruby/gems/2.6.0/"
+  become_user: "{{ redmine_user }}"
+
+- name: Install unicorn's configuration file
+  template:
+    src: unicorn.rb.j2
+    dest: "{{ redmine_home }}/config/unicorn.rb"
+    owner: "{{ redmine_user }}"
+
+- name: Install unicorn's systemd unit
+  template:
+    src: unicorn.units.j2
+    dest: "/lib/systemd/system/unicorn@redmine.service"
+    owner: root
+    group: root
+  notify: Reload systemd
+
+- name: Ensure unicorn is enabled
+  service:
+    name: "unicorn@redmine"
+    enabled: yes
+    state: started

--- a/templates/unicorn.rb.j2
+++ b/templates/unicorn.rb.j2
@@ -1,0 +1,40 @@
+{% for listen in unicorn_listens -%}
+listen "{{ listen }}", :backlog => 1024
+{% endfor -%}
+{% if unicorn_working_directory is defined %}
+working_directory "{{ unicorn_working_directory }}"
+{% endif %}
+{% if unicorn_timeout is defined %}
+timeout {{ unicorn_timeout }}
+{% endif %}
+{% if unicorn_preload_app is defined %}
+preload_app {{ unicorn_preload_app | lower }}
+{% endif %}
+{% if unicorn_worker_processes is defined %}
+worker_processes {{ unicorn_worker_processes }}
+{% endif %}
+{% if unicorn_run_once is defined %}
+run_once = {{ unicorn_run_once | lower }}
+{% endif %}
+before_fork do |server, worker|
+  if run_once
+    run_once = false
+  end
+  old_pid = "#{server.config[:pid]}.oldbin"
+  if old_pid != server.pid
+    begin
+      sig = (worker.nr + 1) >= server.worker_processes ? :QUIT : :TTOU
+      Process.kill(sig, File.read(old_pid).to_i)
+    rescue Errno::ENOENT, Errno::ESRCH
+    end
+  end
+end
+{% if unicorn_pid is defined %}
+pid "{{ unicorn_pid }}"
+{% endif %}
+{% if unicorn_stderr_path is defined %}
+stderr_path "{{ unicorn_stderr_path }}"
+{% endif %}
+{% if unicorn_stdout_path is defined %}
+stdout_path "{{ unicorn_stdout_path }}"
+{% endif %}

--- a/templates/unicorn.units.j2
+++ b/templates/unicorn.units.j2
@@ -1,0 +1,18 @@
+[Unit]
+Description=Unicorn serving redmine
+After=syslog.target
+
+[Service]
+Restart=always
+RestartSec=10
+Type=forking
+WorkingDirectory={{ redmine_home }}
+SyslogIdentifier=unicorn-redmine
+PIDFile={{ unicorn_pid | default(omit)}}
+KillMode=mixed
+KillSignal=SIGQUIT
+User=redmine
+ExecStart={{ redmine_home }}/.rbenv/shims/unicorn -c {{ redmine_home }}/config/unicorn.rb -D -E production
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This PR allows redmine to be deployed along side unicorn as an alternative to passenger. I found it to be the only configuration working well for a deployment in a sub-uri (that is, accessing redmine with www.example.org/redmine).